### PR TITLE
Update Quart to 0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={
         '': ['*.pyi'],
     },
-    install_requires=['Quart>=0.14,<0.15', 'httpx>=0.11,<1.0'],
+    install_requires=['Quart>=0.14,<0.17', 'httpx>=0.11,<1.0'],
     extras_require={
         'all': ['ujson'],
     },


### PR DESCRIPTION
Update Quart to 0.16.0 since it is the first release supporting Python 3.10
Close #61 